### PR TITLE
added battery overcharge warning python code

### DIFF
--- a/scripts/battery_percent.py
+++ b/scripts/battery_percent.py
@@ -1,0 +1,12 @@
+import psutil, time
+import tkinter as tk
+from tkinter import messagebox
+
+root = tk.Tk()
+root.withdraw()
+
+while True:
+    battery = psutil.sensors_battery()
+    if getattr(battery, "percent") >= 70 and getattr(battery, "power_plugged"):
+        messagebox.showinfo(message="Unplug the charger!", parent = root)
+    time.sleep(10)


### PR DESCRIPTION
Warns when battery percent goes above 80%.
Overcharging causes early battery tears and a shorter lifespan.