### PR TITLE
Add Palindrome Checker project (projects/palindrome-checker)

### DIFF
--- a/palindrome/README.md
+++ b/palindrome/README.md
@@ -1,0 +1,16 @@
+# Palindrome Checker
+
+Simple responsive Palindrome Checker web page.
+
+## Usage
+Open `index.html` in a browser and type text. The checker ignores spaces, punctuation and capitalization.
+
+## Example inputs
+- "A man, a plan, a canal — Panama" → palindrome
+- "racecar" → palindrome
+- "hello" → not palindrome
+
+## Files
+- index.html
+- style.css
+- script.js

--- a/palindrome/index.html
+++ b/palindrome/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Palindrome Checker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container">
+    <h1>Palindrome Checker</h1>
+
+    <form id="pal-form" aria-label="Palindrome form">
+      <label for="text">Enter text</label>
+      <input id="text" name="text" type="text" placeholder="Type a word or phrase" required />
+      <div class="controls">
+        <button id="checkBtn" type="submit">Check</button>
+        <button id="clearBtn" type="button">Clear</button>
+      </div>
+    </form>
+
+    <section id="result" aria-live="polite" class="result" hidden></section>
+
+    <small class="hint">Ignoring spaces, punctuation and capitalization.</small>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/palindrome/script.js
+++ b/palindrome/script.js
@@ -1,0 +1,37 @@
+const form = document.getElementById('pal-form');
+const input = document.getElementById('text');
+const result = document.getElementById('result');
+const clearBtn = document.getElementById('clearBtn');
+
+function normalize(s){
+  return s.replace(/[^0-9a-z]/gi, '').toLowerCase();
+}
+
+function isPalindrome(s){
+  const n = normalize(s);
+  let i = 0, j = n.length - 1;
+  while(i < j){
+    if(n[i] !== n[j]) return false;
+    i++; j--;
+  }
+  return true;
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if(!text){
+    result.hidden = false;
+    result.textContent = 'Please enter some text.';
+    return;
+  }
+  const yes = isPalindrome(text);
+  result.hidden = false;
+  result.textContent = yes ? `"${text}" is a palindrome.` : `"${text}" is NOT a palindrome.`;
+});
+
+clearBtn.addEventListener('click', () => {
+  input.value = '';
+  result.hidden = true;
+  input.focus();
+});

--- a/palindrome/style.css
+++ b/palindrome/style.css
@@ -1,0 +1,14 @@
+:root{font-family:system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial}
+*{box-sizing:border-box}
+body{margin:0;padding:2rem;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#f6f8fa}
+.container{max-width:540px;width:100%;background:#fff;padding:1.5rem;border-radius:12px;box-shadow:0 6px 18px rgba(0,0,0,.06)}
+h1{margin:0 0 1rem;font-size:1.5rem}
+label{display:block;margin-bottom:.5rem}
+input[type="text"]{width:100%;padding:.6rem .8rem;border:1px solid #dfe4ea;border-radius:8px;font-size:1rem}
+.controls{margin-top:.75rem;display:flex;gap:.5rem}
+button{padding:.55rem .9rem;border-radius:8px;border:none;cursor:pointer;font-weight:600}
+#checkBtn{background:#0366d6;color:#fff}
+#clearBtn{background:#e6eefc;color:#0366d6}
+.result{margin-top:1rem;padding:.75rem;border-radius:8px;background:#f0f4ff;color:#0b2546}
+.hint{display:block;margin-top:.75rem;color:#6b7280}
+@media (max-width:480px){.container{padding:1rem}}


### PR DESCRIPTION
### What this PR does
Adds a small Palindrome Checker web app under `projects/palindrome-checker` that lets users input text and checks whether it's a palindrome (ignoring spaces, punctuation, and case).

**Files added**
- `projects/palindrome-checker/index.html`
- `projects/palindrome-checker/style.css`
- `projects/palindrome-checker/script.js`
- `projects/palindrome-checker/README.md`

### How to test
1. Open `projects/palindrome-checker/index.html` in a browser.  
2. Type phrases like `"A man, a plan, a canal: Panama"` and press Enter or click **Check**.  
3. Expected: shows **It is a palindrome!**

### Acceptance criteria
- Responsive layout.
- Accessible result announcement (`aria-live`).
- Correct algorithm that ignores non-alphanumeric characters.

### Screenshots
Below are screenshots of the interface (attach images to the PR or include in the repository under `projects/palindrome-checker/screenshots/`):

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9982d739-82eb-4eb2-85bc-57e271af67c2" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe6bae41-8480-4806-bb7f-ada725688cf0" />


Closes #3201 
