### PR TITLE
Refactor UnionFind with type hints and new methods

### DIFF
--- a/algorithms/DSU.py
+++ b/algorithms/DSU.py
@@ -1,22 +1,29 @@
 class UnionFind:
-    def __init__(self, n):
+    """Optimized Union-Find (Disjoint Set Union) with path compression and union by rank."""
+
+    def __init__(self, n: int):
         self.parent = list(range(n))
-        self.rank = [0] * n  # used for union by rank
+        self.rank = [0] * n
+        self.count = n  # optional: track number of disjoint sets
 
-    def find(self, x):
-        # Path compression optimization
-        if self.parent[x] != x:
-            self.parent[x] = self.find(self.parent[x])
-        return self.parent[x]
+    def find(self, x: int) -> int:
+        """Find the representative (root) of the set containing x with path compression."""
+        root = x
+        while root != self.parent[root]:
+            root = self.parent[root]
+        # Path compression (flatten tree)
+        while x != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
 
-    def union(self, x, y):
-        # Union by rank optimization
+    def union(self, x: int, y: int) -> bool:
+        """Union two sets by rank. Returns True if merged, False if already in the same set."""
         root_x = self.find(x)
         root_y = self.find(y)
-
         if root_x == root_y:
-            return False  # already connected
+            return False
 
+        # Attach smaller rank tree under larger one
         if self.rank[root_x] < self.rank[root_y]:
             self.parent[root_x] = root_y
         elif self.rank[root_x] > self.rank[root_y]:
@@ -24,13 +31,26 @@ class UnionFind:
         else:
             self.parent[root_y] = root_x
             self.rank[root_x] += 1
+
+        self.count -= 1  # maintain number of connected components
         return True
 
-# Example usage:
-uf = UnionFind(6)
-uf.union(0, 1)
-uf.union(1, 2)
-uf.union(3, 4)
+    def connected(self, x: int, y: int) -> bool:
+        """Check if two elements belong to the same set."""
+        return self.find(x) == self.find(y)
 
-print(uf.find(0), uf.find(2))  # same group
-print(uf.find(3), uf.find(5))  # different groups
+    def size(self) -> int:
+        """Return the number of disjoint sets."""
+        return self.count
+
+
+# Example usage
+if __name__ == "__main__":
+    uf = UnionFind(6)
+    uf.union(0, 1)
+    uf.union(1, 2)
+    uf.union(3, 4)
+
+    print(uf.connected(0, 2))  # True
+    print(uf.connected(3, 5))  # False
+    print("Number of sets:", uf.size())


### PR DESCRIPTION
🧩 Enhanced Union-Find (Disjoint Set Union) Implementation with Type Hints and Additional Methods
🧠 Problem

The existing Union-Find implementation lacked:

Type hints for readability and static analysis.

Additional helper methods for usability (e.g., connectivity check and disjoint set count).

Inline documentation and clarity for maintainers.

Efficient iterative find() to prevent recursion overhead on large datasets.

💡 Solution

Added type hints and docstrings for better clarity and IDE support.

Rewrote the find() method using an iterative approach with explicit path compression.

Added new methods:

connected(x, y) → checks if two nodes belong to the same set.

size() → returns the current number of disjoint sets.

Included a count attribute to track connected components dynamically.

Improved structure and naming conventions for readability and maintainability.

✅ Changes proposed in this Pull Request:

Refactored the UnionFind class with type hints and docstrings.

Implemented iterative find() for improved performance.

Added connected() and size() methods for enhanced usability.

Added inline documentation for better developer understanding.

Included example usage and improved readability of output.